### PR TITLE
#1 Lower required PHP version to ^7.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     ],
     "minimum-stability": "stable",
     "require": {
-        "php": "^7.2",
+        "php": "^7.1",
         "composer/composer": "^1.6",
         "composer-plugin-api": "^1.1",
         "nikic/php-parser": "^3.0 | ^4.0"


### PR DESCRIPTION
Lowered the required PHP version to ^7.1. 

Test suite passes, but there is no CI set up (see #2).

I've also linted all files against PHP 7.1 and that passes too. 