### PR TITLE
Minor performance improvements

### DIFF
--- a/src/Candidate/CandidateExtractor.php
+++ b/src/Candidate/CandidateExtractor.php
@@ -50,23 +50,9 @@ class CandidateExtractor implements CandidateExtractorInterface
         $installed  = $repository->getPackages();
 
         foreach ($packages as $name => $symbols) {
-            $package = array_reduce(
-                $installed,
-                function (
-                    ?PackageInterface $carry,
-                    PackageInterface $package
-                ) use (
-                    $name
-                ): ?PackageInterface {
-                    return $carry ?? (
-                        $package->getName() === $name
-                            ? $package
-                            : null
-                        );
-                }
-            );
+            $package = $this->getPackageByName($installed, $name);
 
-            if (!$package instanceof PackageInterface) {
+            if ($package === null) {
                 continue;
             }
 
@@ -77,6 +63,22 @@ class CandidateExtractor implements CandidateExtractorInterface
         }
 
         return $candidates;
+    }
+
+    /**
+     * @param PackageInterface[]|iterable $packages
+     * @param string $name
+     * @return PackageInterface|null
+     */
+    private function getPackageByName(iterable $packages, string $name): ?PackageInterface
+    {
+        foreach ($packages as $package) {
+            if ($package->getName() === $name) {
+                return $package;
+            }
+        }
+
+        return null;
     }
 
     /**

--- a/src/Candidate/CandidateExtractor.php
+++ b/src/Candidate/CandidateExtractor.php
@@ -46,8 +46,9 @@ class CandidateExtractor implements CandidateExtractorInterface
             $packages[$package][] = $symbol;
         }
 
+        $installed = $repository->getPackages();
+
         $candidates = [];
-        $installed  = $repository->getPackages();
 
         foreach ($packages as $name => $symbols) {
             $package = $this->getPackageByName($installed, $name);
@@ -67,7 +68,8 @@ class CandidateExtractor implements CandidateExtractorInterface
 
     /**
      * @param PackageInterface[]|iterable $packages
-     * @param string $name
+     * @param string                      $name
+     *
      * @return PackageInterface|null
      */
     private function getPackageByName(iterable $packages, string $name): ?PackageInterface

--- a/src/Php/Filter/SymbolFilterChain.php
+++ b/src/Php/Filter/SymbolFilterChain.php
@@ -30,17 +30,13 @@ class SymbolFilterChain implements SymbolFilterInterface
      */
     public function __invoke(string $symbol): bool
     {
-        return array_reduce(
-            $this->filters,
-            function (
-                bool $carry,
-                SymbolFilterInterface $filter
-            ) use (
-                $symbol
-            ) : bool {
-                return $carry && $filter($symbol);
-            },
-            true
-        );
+        foreach ($this->filters as $filter)
+        {
+            if (!$filter->__invoke($symbol)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/src/Php/Filter/SymbolFilterChain.php
+++ b/src/Php/Filter/SymbolFilterChain.php
@@ -30,8 +30,7 @@ class SymbolFilterChain implements SymbolFilterInterface
      */
     public function __invoke(string $symbol): bool
     {
-        foreach ($this->filters as $filter)
-        {
+        foreach ($this->filters as $filter) {
             if (!$filter->__invoke($symbol)) {
                 return false;
             }

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -48,13 +48,13 @@ class SymbolExtractor implements SymbolExtractorInterface
         $symbols = [];
 
         foreach ($files as $file) {
-            if (!$file->isFile() || !$file->isReadable()) {
-                continue;
-            }
-
             try {
-                $handle     = $file->openFile('r');
-                $contents   = implode('', iterator_to_array($handle));
+                $contents   = @\file_get_contents($file);
+
+                if ($contents === false) {
+                    continue;
+                }
+
                 $statements = $this->parser->parse($contents);
             } catch (Error $e) {
                 // Either not a PHP file or the broken file should be detected by other

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -49,7 +49,13 @@ class SymbolExtractor implements SymbolExtractorInterface
 
         foreach ($files as $file) {
             try {
-                $contents = $this->readFile($file);
+
+                $handle   = $file->openFile('rb');
+                $contents = $handle->fread($file->getSize());
+
+                if ($contents === false) {
+                    continue;
+                }
 
                 $statements = $this->parser->parse($contents);
             } catch (Error $e) {
@@ -69,16 +75,5 @@ class SymbolExtractor implements SymbolExtractorInterface
         }
 
         return new SymbolIterator(...$symbols);
-    }
-
-    /**
-     * @param \SplFileInfo $file
-     *
-     * @return string
-     */
-    private function readFile(\SplFileInfo $file): string
-    {
-        $handle = $file->openFile('rb');
-        return $handle->fread($file->getSize());
     }
 }

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -51,14 +51,10 @@ class SymbolExtractor implements SymbolExtractorInterface
             try {
                 $contents = $this->readFile($file);
 
-                if ($contents === null) {
-                    continue;
-                }
-
                 $statements = $this->parser->parse($contents);
             } catch (Error $e) {
-                // Either not a PHP file or the broken file should be detected by other
-                // tooling entirely.
+                // Either not a file, file is not readable, not a PHP file or
+                // the broken file should be detected by other tooling entirely.
                 continue;
             }
 
@@ -82,7 +78,7 @@ class SymbolExtractor implements SymbolExtractorInterface
      */
     private function readFile(\SplFileInfo $file): string
     {
-        $handle   = $file->openFile('rb');
+        $handle = $file->openFile('rb');
         return $handle->fread($file->getSize());
     }
 }

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -78,24 +78,11 @@ class SymbolExtractor implements SymbolExtractorInterface
     /**
      * @param \SplFileInfo $file
      *
-     * @return null|string
+     * @return string
      */
-    private function readFile(\SplFileInfo $file): ?string
+    private function readFile(\SplFileInfo $file): string
     {
-        $oldErrorReporting = error_reporting();
-
-        error_reporting($oldErrorReporting & ~E_WARNING);
-
-        try {
-            $contents = \file_get_contents($file);
-
-            if ($contents === false) {
-                return null;
-            }
-
-            return $contents;
-        } finally {
-            error_reporting($oldErrorReporting);
-        }
+        $handle   = $file->openFile('rb');
+        return $handle->fread($file->getSize());
     }
 }

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -49,11 +49,10 @@ class SymbolExtractor implements SymbolExtractorInterface
 
         foreach ($files as $file) {
             try {
-
                 $handle   = $file->openFile('rb');
                 $contents = $handle->fread($file->getSize());
 
-                if ($contents === false) {
+                if (!$contents) { // phpstan thinks this can only return string.
                     continue;
                 }
 

--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -49,9 +49,9 @@ class SymbolExtractor implements SymbolExtractorInterface
 
         foreach ($files as $file) {
             try {
-                $contents   = @\file_get_contents($file);
+                $contents = $this->readFile($file);
 
-                if ($contents === false) {
+                if ($contents === null) {
                     continue;
                 }
 
@@ -73,5 +73,29 @@ class SymbolExtractor implements SymbolExtractorInterface
         }
 
         return new SymbolIterator(...$symbols);
+    }
+
+    /**
+     * @param \SplFileInfo $file
+     *
+     * @return null|string
+     */
+    private function readFile(\SplFileInfo $file): ?string
+    {
+        $oldErrorReporting = error_reporting();
+
+        error_reporting($oldErrorReporting & ~E_WARNING);
+
+        try {
+            $contents = \file_get_contents($file);
+
+            if ($contents === false) {
+                return null;
+            }
+
+            return $contents;
+        } finally {
+            error_reporting($oldErrorReporting);
+        }
     }
 }

--- a/src/Php/SymbolTracker.php
+++ b/src/Php/SymbolTracker.php
@@ -72,16 +72,13 @@ class SymbolTracker extends NodeVisitorAbstract implements
      */
     public function getSymbols(): iterable
     {
-        return array_reduce(
-            array_filter($this->symbols),
-            function (array $carry, array $names) : array {
-                foreach ($names as $name) {
-                    $carry[] = $name;
-                }
-
-                return $carry;
-            },
-            []
+        return new \CallbackFilterIterator(
+            new \RecursiveIteratorIterator(
+                new \RecursiveArrayIterator($this->symbols, \RecursiveArrayIterator::CHILD_ARRAYS_ONLY)
+            ),
+            function ($each): bool {
+                return $each !== false;
+            }
         );
     }
 }

--- a/src/Violation/Filter/ViolationFilterChain.php
+++ b/src/Violation/Filter/ViolationFilterChain.php
@@ -32,17 +32,12 @@ class ViolationFilterChain implements ViolationFilterInterface
      */
     public function __invoke(ViolationInterface $violation): bool
     {
-        return array_reduce(
-            $this->filters,
-            function (
-                bool $carry,
-                ViolationFilterInterface $filter
-            ) use (
-                $violation
-            ) : bool {
-                return $carry && $filter($violation);
-            },
-            true
-        );
+        foreach ($this->filters as $filter) {
+            if (!$filter->__invoke($violation)) {
+                return false;
+            }
+        }
+
+        return true;
     }
 }

--- a/tests/Candidate/CandidateExtractorTest.php
+++ b/tests/Candidate/CandidateExtractorTest.php
@@ -35,6 +35,7 @@ class CandidateExtractorTest extends TestCase
      *
      * @covers ::extract
      * @covers ::extractPackage
+     * @covers ::getPackageByName
      */
     public function testExtract(
         Composer $composer,

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -45,7 +45,7 @@ class SymbolExtractorTest extends TestCase
 
     /**
      * @dataProvider emptyProvider
-     * @dataProvider emptyFilesProvider
+     * @dataProvider unparsableFilesProvider
      * @dataProvider filledFilesProvider
      *
      * @param Parser                $parser
@@ -160,7 +160,7 @@ class SymbolExtractorTest extends TestCase
     /**
      * @return Parser[][]|FileIteratorInterface[][]
      */
-    public function emptyFilesProvider(): array
+    public function unparsableFilesProvider(): array
     {
         $parser = $this->createMock(Parser::class);
 
@@ -176,9 +176,9 @@ class SymbolExtractorTest extends TestCase
             [
                 $parser,
                 $this->createFileIterator(
-                    $this->createFile(''),
-                    $this->createFile(''),
-                    $this->createFile('')
+                    $this->createFile('x'),
+                    $this->createFile('y'),
+                    $this->createFile('z')
                 )
             ]
         ];

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -45,7 +45,6 @@ class SymbolExtractorTest extends TestCase
 
     /**
      * @dataProvider emptyProvider
-     * @dataProvider illegalFilesProvider
      * @dataProvider emptyFilesProvider
      * @dataProvider filledFilesProvider
      *
@@ -156,43 +155,15 @@ class SymbolExtractorTest extends TestCase
             ->method('isReadable')
             ->willReturn($content !== null);
 
+        $tempFile = tempnam(sys_get_temp_dir(), "");
+        file_put_contents($tempFile, $content);
+
         $fileInfo
             ->expects(self::any())
-            ->method('openFile')
-            ->with(self::isType('string'))
-            ->willReturnCallback(
-                function (string $mode) use ($content) {
-                    $file = new SplFileObject('php://memory', $mode);
-                    $file->fwrite((string)$content);
-
-                    return $file;
-                }
-            );
+            ->method('__toString')
+            ->willReturn($tempFile);
 
         return $fileInfo;
-    }
-
-    /**
-     * @return Parser[][]|FileIteratorInterface[][]
-     */
-    public function illegalFilesProvider(): array
-    {
-        $parser = $this->createMock(Parser::class);
-
-        $parser
-            ->expects(self::never())
-            ->method('parse')
-            ->with(self::anything());
-
-        return [
-            [
-                $parser,
-                $this->createFileIterator(
-                    $this->createDirectory(),
-                    $this->createFile()
-                )
-            ]
-        ];
     }
 
     /**

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -120,32 +120,39 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @param string|null $content
+     * @param string $content
      *
-     * @return SplFileInfo
+     * @return SplFileInfo|\PHPUnit_Framework_MockObject_MockObject
      */
-    private function createFile(string $content = null): SplFileInfo
+    private function createFile(string $content): SplFileInfo
     {
         /** @var SplFileInfo|MockObject $fileInfo */
         $fileInfo = $this->createMock(SplFileInfo::class);
 
         $fileInfo
-            ->expects(self::any())
             ->method('isFile')
             ->willReturn(true);
 
         $fileInfo
-            ->expects(self::any())
             ->method('isReadable')
             ->willReturn($content !== null);
 
-        $tempFile = tempnam(sys_get_temp_dir(), "");
-        file_put_contents($tempFile, $content);
+        $fileInfo
+            ->method("getSize")
+            ->willReturn(\strlen($content));
+
+        $handle = $this->getMockBuilder(\SplFileObject::class)
+            ->enableOriginalConstructor()
+            ->setConstructorArgs([tempnam(sys_get_temp_dir(), "")])
+            ->getMock();
+
+        $handle
+            ->method("fread")
+            ->willReturn($content);
 
         $fileInfo
-            ->expects(self::any())
-            ->method('__toString')
-            ->willReturn($tempFile);
+            ->method('openFile')
+            ->willReturn($handle);
 
         return $fileInfo;
     }

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -120,22 +120,6 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return SplFileInfo
-     */
-    private function createDirectory(): SplFileInfo
-    {
-        /** @var SplFileInfo|MockObject $directory */
-        $directory = $this->createMock(SplFileInfo::class);
-
-        $directory
-            ->expects(self::any())
-            ->method('isFile')
-            ->willReturn(false);
-
-        return $directory;
-    }
-
-    /**
      * @param string|null $content
      *
      * @return SplFileInfo

--- a/tests/Php/SymbolTrackerTest.php
+++ b/tests/Php/SymbolTrackerTest.php
@@ -43,7 +43,9 @@ class SymbolTrackerTest extends TestCase
             $subject->enterNode($node);
         }
 
-        $this->assertEquals($expected, $subject->getSymbols());
+        $actual = iterator_to_array($subject->getSymbols());
+
+        $this->assertSame($expected, $actual);
     }
 
     /**


### PR DESCRIPTION
Some minor performance improvements.

* Reduce usage of `array_reduce` so we don't have to loop the entire array
* Use `file_get_contents()` to read the file in one I/O operation. 
* Remove checks for isFile() and isReadable(), check error result from `file_get_contents` instead.

Initial profile against a reasonable sized code base (90% of calls):

* 4953 different functions called in 165771 milliseconds (1 runs, 37 shown)

Final profile:

* 4950 different functions called in 144280 milliseconds (1 runs, 33 shown)

±15% speed up.