### PR TITLE
1.0.3 - Fix fread call when file size is zero

### DIFF
--- a/src/Php/SymbolExtractor.php
+++ b/src/Php/SymbolExtractor.php
@@ -49,10 +49,11 @@ class SymbolExtractor implements SymbolExtractorInterface
 
         foreach ($files as $file) {
             try {
+                $size     = $file->getSize();
                 $handle   = $file->openFile('rb');
-                $contents = $handle->fread($file->getSize());
+                $contents = $size  > 0 ? $handle->fread($size) : '';
 
-                if (!$contents) { // phpstan thinks this can only return string.
+                if (empty($contents)) {
                     continue;
                 }
 

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -45,7 +45,7 @@ class SymbolExtractorTest extends TestCase
 
     /**
      * @dataProvider emptyProvider
-     * @dataProvider unparsableFilesProvider
+     * @dataProvider nonParsingFilesProvider
      * @dataProvider filledFilesProvider
      *
      * @param Parser                $parser
@@ -115,14 +115,20 @@ class SymbolExtractorTest extends TestCase
             ->with(self::anything());
 
         return [
-            [$parser, $this->createFileIterator()]
+            [$parser, $this->createFileIterator()],
+            [
+                $parser,
+                $this->createFileIterator(
+                    $this->createFile('')
+                )
+            ]
         ];
     }
 
     /**
      * @param string $content
      *
-     * @return SplFileInfo|\PHPUnit_Framework_MockObject_MockObject
+     * @return SplFileInfo
      */
     private function createFile(string $content): SplFileInfo
     {
@@ -141,7 +147,7 @@ class SymbolExtractorTest extends TestCase
             ->method("getSize")
             ->willReturn(\strlen($content));
 
-        $handle = $this->getMockBuilder(\SplFileObject::class)
+        $handle = $this->getMockBuilder(SplFileObject::class)
             ->enableOriginalConstructor()
             ->setConstructorArgs([tempnam(sys_get_temp_dir(), "")])
             ->getMock();
@@ -160,7 +166,7 @@ class SymbolExtractorTest extends TestCase
     /**
      * @return Parser[][]|FileIteratorInterface[][]
      */
-    public function unparsableFilesProvider(): array
+    public function nonParsingFilesProvider(): array
     {
         $parser = $this->createMock(Parser::class);
 


### PR DESCRIPTION
When the file size is zero, the call to `SplFileObject::fread` fails,
because it only accepts a size greater than zero.
This has been fixed by testing the size and optionally falling back to
an empty string.

The unit test has been expanded to prevent regression.

Fixes #15 