### PR TITLE
Add known limitations

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,3 +152,59 @@ The configuration above will ignore violations for the following packages:
 - `acme/tnt`
 - `symfony/console`
 - `league/flysystem`
+
+# Known limitations
+
+Some scenarios cannot be covered by Dependency Guard, in its current form.
+Known limitations are listed below:
+
+## 🦊 Pokémon exception handling combined with integration tests
+
+[Pókemon exception handling](http://wiki.c2.com/?PokemonExceptionHandling) is also known as:
+
+- :stars: [Yoda Exception Handling](http://wiki.c2.com/?YodaExceptionHandling)
+- :trollface: [Error Hiding](https://en.wikipedia.org/wiki/Error_hiding)
+- :poop: [Diaper pattern](http://mike.pirnat.com/2009/05/09/the-diaper-pattern-stinks/)
+
+This methodology catches any and all exceptions and either forwards them or ignores them:
+
+```php
+<?php
+try {
+    doSomething();
+} catch (Throwable $exception) {
+    // Do nothing.
+}
+```
+
+When this is used to handle exceptions in an application, the following issue is caused by
+running integration tests on that code.
+
+When the test sets an expectation / assertion, the assertion may fail. When the assertion
+fails, it throws a corresponding exception, which is meant to be caught by the test framework.
+
+Instead it is caught by the exception handling as described above. To counteract this, the
+following ends up in production code:
+
+```php
+<?php
+try {
+    doSomething();
+} catch (\PHPUnit\Framework\AssertionFailedError $assertionException) {
+    // Re-throw the exception, as it is part of the testing framework.
+    throw $assertionException;
+} catch (Throwable $exception) {
+    // Do nothing.
+}
+```
+
+The code above causes DependencyGuard, to detect that
+`\PHPUnit\Framework\AssertionFailedError` is a symbol that can only be available when
+a development installation is used. It may be expected that, since this symbol is only
+used within a `catch`, it is not "really" a dependency, as it will only be autoloaded
+when that specific `catch` is reached. DependencyGuard does no such specific inspection
+of the symbol at hand. The exception is thus marked as dependency violation.
+
+There are currently no plans to solve this. That being said, pull requests and open
+discussions on this matter are welcomed.
+


### PR DESCRIPTION
Describe known limitations to the detection of dependency issues.
Closes #7.

The additions to the documentation are a direct result of a conversation with @willemstuursma on how to approach this problem.