### PR TITLE
Exclude specific files from archives

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,12 @@
+/CODE_OF_CONDUCT.md export-ignore
+/CONTRIBUTING.md export-ignore
+/.github export-ignore
+/.gitattributes export-ignore
+/.gitignore export-ignore
+/grumphp.dist.yml export-ignore
+/phpunit.xml export-ignore
+/phpmd.xml export-ignore
+/phpstan.neon export-ignore
+/phpcs.xml export-ignore
+/bitbucket-pipelines.yml export-ignore
+/tests export-ignore

--- a/composer.json
+++ b/composer.json
@@ -54,7 +54,12 @@
     },
     "archive": {
         "exclude": [
+            "/CODE_OF_CONDUCT.md",
+            "/CONTRIBUTING.md",
+            "/.github",
+            "/.gitattributes",
             "/.gitignore",
+            "/grumphp.dist.yml",
             "/phpunit.xml",
             "/phpmd.xml",
             "/phpstan.neon",


### PR DESCRIPTION
By adding files to `archive.exclude` within `composer.json`, the dist
package is kept clean when composer is generating an archive. However,
Github also creates a dist file, using `.gitattributes`. Hence, the
exclude rules are copied over to `.gitattributes`.