### PR TITLE
1.0.4 - Analyze PHP symbols without loading their files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php": "^7.1",
         "composer/composer": "^1.6",
         "composer-plugin-api": "^1.1",
-        "nikic/php-parser": "^3.0 | ^4.0"
+        "nikic/php-parser": "^3.0 | ^4.0",
+        "roave/better-reflection": "^3.1"
     },
     "require-dev": {
         "mediact/testing-suite": "@stable",

--- a/src/Candidate/CandidateExtractor.php
+++ b/src/Candidate/CandidateExtractor.php
@@ -11,7 +11,7 @@ use Composer\Package\PackageInterface;
 use Mediact\DependencyGuard\Php\SymbolInterface;
 use Mediact\DependencyGuard\Php\SymbolIterator;
 use Mediact\DependencyGuard\Php\SymbolIteratorInterface;
-use ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 
 class CandidateExtractor implements CandidateExtractorInterface
 {
@@ -100,7 +100,7 @@ class CandidateExtractor implements CandidateExtractorInterface
         $name = $symbol->getName();
 
         if (!array_key_exists($name, $packagesPerSymbol)) {
-            $reflection = new ReflectionClass($name);
+            $reflection = ReflectionClass::createFromName($name);
             $file       = $reflection->getFileName();
 
             // This happens for symbols in the current package.

--- a/src/Php/Filter/UserDefinedSymbolFilter.php
+++ b/src/Php/Filter/UserDefinedSymbolFilter.php
@@ -6,7 +6,7 @@
 
 namespace Mediact\DependencyGuard\Php\Filter;
 
-use ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Throwable;
 
 class UserDefinedSymbolFilter implements SymbolFilterInterface
@@ -21,7 +21,7 @@ class UserDefinedSymbolFilter implements SymbolFilterInterface
     public function __invoke(string $symbol): bool
     {
         try {
-            $reflection = new ReflectionClass($symbol);
+            $reflection = ReflectionClass::createFromName($symbol);
         } catch (Throwable $e) {
             return false;
         }

--- a/tests/Composer/Command/DependencyGuardCommandTest.php
+++ b/tests/Composer/Command/DependencyGuardCommandTest.php
@@ -8,6 +8,7 @@ namespace Mediact\DependencyGuard\Tests\Composer\Command;
 
 use Composer\Composer;
 use Composer\Config;
+use Composer\EventDispatcher\EventDispatcher;
 use Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactoryInterface;
 use Mediact\DependencyGuard\DependencyGuardFactoryInterface;
 use Mediact\DependencyGuard\DependencyGuardInterface;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @coversDefaultClass \Mediact\DependencyGuard\Composer\Command\DependencyGuardCommand
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DependencyGuardCommandTest extends TestCase
 {
@@ -63,6 +65,13 @@ class DependencyGuardCommandTest extends TestCase
             ->expects(self::any())
             ->method('getConfig')
             ->willReturn($config);
+
+        $composer
+            ->expects(self::any())
+            ->method('getEventDispatcher')
+            ->willReturn(
+                $this->createMock(EventDispatcher::class)
+            );
 
         $config
             ->expects(self::any())

--- a/tests/GrumPHP/DependencyGuardTest.php
+++ b/tests/GrumPHP/DependencyGuardTest.php
@@ -99,7 +99,7 @@ class DependencyGuardTest extends TestCase
     }
 
     /**
-     * @return ContextInterface[][]|bool[][]
+     * @return array
      */
     public function contextProvider(): array
     {
@@ -223,7 +223,7 @@ class DependencyGuardTest extends TestCase
     }
 
     /**
-     * @return DependencyGuardInterface[][]|bool[][]
+     * @return array
      */
     public function guardProvider(): array
     {

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -103,7 +103,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function emptyProvider(): array
     {
@@ -164,7 +164,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function nonParsingFilesProvider(): array
     {
@@ -191,7 +191,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function filledFilesProvider(): array
     {

--- a/tests/Php/SymbolTest.php
+++ b/tests/Php/SymbolTest.php
@@ -76,7 +76,7 @@ class SymbolTest extends TestCase
     }
 
     /**
-     * @return Name[][]|string[][]
+     * @return array
      */
     public function nameProvider(): array
     {
@@ -126,7 +126,7 @@ class SymbolTest extends TestCase
     }
 
     /**
-     * @return Name[][]|string[][]
+     * @return array
      */
     public function lineProvider(): array
     {

--- a/tests/Php/SymbolTrackerTest.php
+++ b/tests/Php/SymbolTrackerTest.php
@@ -71,7 +71,7 @@ class SymbolTrackerTest extends TestCase
     }
 
     /**
-     * @return SymbolFilterInterface[][]|Node[][][]|Node[][]
+     * @return array
      */
     public function whitelistedNodesProvider(): array
     {
@@ -100,7 +100,7 @@ class SymbolTrackerTest extends TestCase
     }
 
     /**
-     * @return SymbolFilterInterface[][]|Node[][][]|Node[][]
+     * @return array
      */
     public function blacklistedNodesProvider(): array
     {

--- a/tests/Violation/Filter/ViolationFilterChainTest.php
+++ b/tests/Violation/Filter/ViolationFilterChainTest.php
@@ -42,7 +42,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]
+     * @return array
      */
     public function emptyProvider(): array
     {
@@ -79,7 +79,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]|ViolationFilterInterface[][]
+     * @return array
      */
     public function matchingProvider(): array
     {
@@ -116,7 +116,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]|ViolationFilterInterface[][]
+     * @return array
      */
     public function nonMatchingProvider(): array
     {


### PR DESCRIPTION
This pull request fixes #21 

Issue #21 describes how the files that are analyzed are loaded in the active code base. When DependencyGuard is used to analyze files that are also present in the active code base, they can conflict and cause fatal errors.

This pull requests implements [BetterReflection](https://packagist.org/packages/roave/better-reflection) to determine all necessary information about code symbols without loading in their files, through the autoloader.

**N.B.:** This pull request should not be merged before @Idrinth confirms this solves the issue.