### PR TITLE
1.0.4 - Prevent autoloading targets of static analysis

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
         "roave/better-reflection": "^3.1"
     },
     "require-dev": {
+        "symfony/process": "@stable",
         "mediact/testing-suite": "@stable",
         "mikey179/vfsstream": "^1.6",
         "phpro/grumphp": "~0.1",

--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,8 @@
         "php": "^7.1",
         "composer/composer": "^1.6",
         "composer-plugin-api": "^1.1",
-        "nikic/php-parser": "^3.0 | ^4.0"
+        "nikic/php-parser": "^3.0 | ^4.0",
+        "roave/better-reflection": "^3.1"
     },
     "require-dev": {
         "mediact/testing-suite": "@stable",

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -5,6 +5,9 @@
         <testsuite name="default">
             <directory>tests</directory>
         </testsuite>
+        <testsuite name="regression">
+            <directory>tests/Regression</directory>
+        </testsuite>
     </testsuites>
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/src/Candidate/CandidateExtractor.php
+++ b/src/Candidate/CandidateExtractor.php
@@ -11,7 +11,7 @@ use Composer\Package\PackageInterface;
 use Mediact\DependencyGuard\Php\SymbolInterface;
 use Mediact\DependencyGuard\Php\SymbolIterator;
 use Mediact\DependencyGuard\Php\SymbolIteratorInterface;
-use ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 
 class CandidateExtractor implements CandidateExtractorInterface
 {
@@ -100,7 +100,7 @@ class CandidateExtractor implements CandidateExtractorInterface
         $name = $symbol->getName();
 
         if (!array_key_exists($name, $packagesPerSymbol)) {
-            $reflection = new ReflectionClass($name);
+            $reflection = ReflectionClass::createFromName($name);
             $file       = $reflection->getFileName();
 
             // This happens for symbols in the current package.

--- a/src/Composer/Command/DependencyGuardCommand.php
+++ b/src/Composer/Command/DependencyGuardCommand.php
@@ -7,7 +7,6 @@
 namespace Mediact\DependencyGuard\Composer\Command;
 
 use Composer\Command\BaseCommand;
-use Composer\Composer;
 use Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactory;
 use Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactoryInterface;
 use Mediact\DependencyGuard\DependencyGuardFactory;
@@ -85,37 +84,15 @@ class DependencyGuardCommand extends BaseCommand
         InputInterface $input,
         OutputInterface $output
     ): int {
-        $composer = $this->getComposer(true);
-        $guard    = $this->guardFactory->create();
-
-        $this->registerAutoloader($composer);
+        $composer   = $this->getComposer(true);
+        $guard      = $this->guardFactory->create();
         $violations = $guard->determineViolations($composer);
+        $exporter   = $this->exporterFactory->create($input, $output);
 
-        $exporter = $this->exporterFactory->create($input, $output);
         $exporter->export($violations);
 
         return count($violations) > 0
             ? static::EXIT_VIOLATIONS
             : static::EXIT_NO_VIOLATIONS;
-    }
-
-    /**
-     * Register the autoloader for the current project, so subject classes can
-     * be automatically loaded.
-     *
-     * @param Composer $composer
-     *
-     * @return void
-     */
-    private function registerAutoloader(Composer $composer): void
-    {
-        $config     = $composer->getConfig();
-        $vendor     = $config->get('vendor-dir', 0);
-        $autoloader = $vendor . DIRECTORY_SEPARATOR . 'autoload.php';
-
-        if (is_readable($autoloader)) {
-            /** @noinspection PhpIncludeInspection */
-            require_once $autoloader;
-        }
     }
 }

--- a/src/Php/Filter/UserDefinedSymbolFilter.php
+++ b/src/Php/Filter/UserDefinedSymbolFilter.php
@@ -6,7 +6,7 @@
 
 namespace Mediact\DependencyGuard\Php\Filter;
 
-use ReflectionClass;
+use Roave\BetterReflection\Reflection\ReflectionClass;
 use Throwable;
 
 class UserDefinedSymbolFilter implements SymbolFilterInterface
@@ -21,7 +21,7 @@ class UserDefinedSymbolFilter implements SymbolFilterInterface
     public function __invoke(string $symbol): bool
     {
         try {
-            $reflection = new ReflectionClass($symbol);
+            $reflection = ReflectionClass::createFromName($symbol);
         } catch (Throwable $e) {
             return false;
         }

--- a/tests/Composer/Command/DependencyGuardCommandTest.php
+++ b/tests/Composer/Command/DependencyGuardCommandTest.php
@@ -91,7 +91,6 @@ class DependencyGuardCommandTest extends TestCase
      * @return void
      *
      * @covers ::execute
-     * @covers ::registerAutoloader
      */
     public function testExecute(
         ViolationIteratorInterface $violations,

--- a/tests/Composer/Command/DependencyGuardCommandTest.php
+++ b/tests/Composer/Command/DependencyGuardCommandTest.php
@@ -8,6 +8,7 @@ namespace Mediact\DependencyGuard\Tests\Composer\Command;
 
 use Composer\Composer;
 use Composer\Config;
+use Composer\EventDispatcher\EventDispatcher;
 use Mediact\DependencyGuard\Composer\Command\Exporter\ViolationExporterFactoryInterface;
 use Mediact\DependencyGuard\DependencyGuardFactoryInterface;
 use Mediact\DependencyGuard\DependencyGuardInterface;
@@ -22,6 +23,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 /**
  * @coversDefaultClass \Mediact\DependencyGuard\Composer\Command\DependencyGuardCommand
+ * @SuppressWarnings(PHPMD.CouplingBetweenObjects)
  */
 class DependencyGuardCommandTest extends TestCase
 {
@@ -63,6 +65,13 @@ class DependencyGuardCommandTest extends TestCase
             ->expects(self::any())
             ->method('getConfig')
             ->willReturn($config);
+
+        $composer
+            ->expects(self::any())
+            ->method('getEventDispatcher')
+            ->willReturn(
+                $this->createMock(EventDispatcher::class)
+            );
 
         $config
             ->expects(self::any())

--- a/tests/GrumPHP/DependencyGuardTest.php
+++ b/tests/GrumPHP/DependencyGuardTest.php
@@ -99,7 +99,7 @@ class DependencyGuardTest extends TestCase
     }
 
     /**
-     * @return ContextInterface[][]|bool[][]
+     * @return array
      */
     public function contextProvider(): array
     {
@@ -223,7 +223,7 @@ class DependencyGuardTest extends TestCase
     }
 
     /**
-     * @return DependencyGuardInterface[][]|bool[][]
+     * @return array
      */
     public function guardProvider(): array
     {

--- a/tests/Php/SymbolExtractorTest.php
+++ b/tests/Php/SymbolExtractorTest.php
@@ -103,7 +103,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function emptyProvider(): array
     {
@@ -164,7 +164,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function nonParsingFilesProvider(): array
     {
@@ -191,7 +191,7 @@ class SymbolExtractorTest extends TestCase
     }
 
     /**
-     * @return Parser[][]|FileIteratorInterface[][]
+     * @return array
      */
     public function filledFilesProvider(): array
     {

--- a/tests/Php/SymbolTest.php
+++ b/tests/Php/SymbolTest.php
@@ -76,7 +76,7 @@ class SymbolTest extends TestCase
     }
 
     /**
-     * @return Name[][]|string[][]
+     * @return array
      */
     public function nameProvider(): array
     {
@@ -126,7 +126,7 @@ class SymbolTest extends TestCase
     }
 
     /**
-     * @return Name[][]|string[][]
+     * @return array
      */
     public function lineProvider(): array
     {

--- a/tests/Php/SymbolTrackerTest.php
+++ b/tests/Php/SymbolTrackerTest.php
@@ -71,7 +71,7 @@ class SymbolTrackerTest extends TestCase
     }
 
     /**
-     * @return SymbolFilterInterface[][]|Node[][][]|Node[][]
+     * @return array
      */
     public function whitelistedNodesProvider(): array
     {
@@ -100,7 +100,7 @@ class SymbolTrackerTest extends TestCase
     }
 
     /**
-     * @return SymbolFilterInterface[][]|Node[][][]|Node[][]
+     * @return array
      */
     public function blacklistedNodesProvider(): array
     {

--- a/tests/Regression/Issue21/Issue21Test.php
+++ b/tests/Regression/Issue21/Issue21Test.php
@@ -1,0 +1,55 @@
+<?php
+
+namespace Mediact\DependencyGuard\Tests\Regression\Issue21;
+
+use PHPUnit\Framework\TestCase;
+
+class Issue21Test extends TestCase
+{
+    /**
+     * @return void
+     */
+    public function setUp(): void
+    {
+        exec("composer install --quiet --working-dir=".escapeshellarg(__DIR__), $output, $return);
+        if ($return !== 0) {
+            self::markTestSkipped(implode(PHP_EOL, $output));
+        }
+    }
+
+    /**
+     * @coversNothing
+     * @return void
+     */
+    public function testNoFatalsBecauseOfConflicts(): void
+    {
+        self::assertNotContains(
+            'Fatal error:',
+            shell_exec('cd '.escapeshellarg(__DIR__).' && php ../../../bin/dependency-guard').''
+        );
+    }
+
+    /**
+     * @return void
+     */
+    public function tearDown(): void
+    {
+       $this->delete(__DIR__.DIRECTORY_SEPARATOR.'vendor');
+    }
+
+    /**
+     * @param string $dir
+     */
+    private function delete(string $dir): void
+    {
+        foreach (array_diff(scandir($dir), ['.', '..']) as $file) {
+            $file = $dir.DIRECTORY_SEPARATOR.$file;
+            if (is_file($file)) {
+                unlink($file);
+            } elseif (is_dir($file)) {
+                $this->delete($file);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Regression/Issue21/composer.json
+++ b/tests/Regression/Issue21/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "issue21/test",
+    "require": {
+        "symfony/console": "2.8.45"
+    }
+}

--- a/tests/Regression/Issue21/composer.lock
+++ b/tests/Regression/Issue21/composer.lock
@@ -1,0 +1,242 @@
+{
+    "_readme": [
+        "This file locks the dependencies of your project to a known state",
+        "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
+        "This file is @generated automatically"
+    ],
+    "content-hash": "d1a5af04abd836c57137646c0b398a5a",
+    "packages": [
+        {
+            "name": "psr/log",
+            "version": "1.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-fig/log.git",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-fig/log/zipball/4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "reference": "4ebe3a8bf773a19edfe0a84b6585ba3d401b724d",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Psr\\Log\\": "Psr/Log/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "PHP-FIG",
+                    "homepage": "http://www.php-fig.org/"
+                }
+            ],
+            "description": "Common interface for logging libraries",
+            "homepage": "https://github.com/php-fig/log",
+            "keywords": [
+                "log",
+                "psr",
+                "psr-3"
+            ],
+            "time": "2016-10-10T12:19:37+00:00"
+        },
+        {
+            "name": "symfony/console",
+            "version": "v2.8.45",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/console.git",
+                "reference": "0c1fcbb9afb5cff992c982ff99c0434f0146dcfc"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/console/zipball/0c1fcbb9afb5cff992c982ff99c0434f0146dcfc",
+                "reference": "0c1fcbb9afb5cff992c982ff99c0434f0146dcfc",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.9",
+                "symfony/debug": "^2.7.2|~3.0.0",
+                "symfony/polyfill-mbstring": "~1.0"
+            },
+            "require-dev": {
+                "psr/log": "~1.0",
+                "symfony/event-dispatcher": "~2.1|~3.0.0",
+                "symfony/process": "~2.1|~3.0.0"
+            },
+            "suggest": {
+                "psr/log-implementation": "For using the console logger",
+                "symfony/event-dispatcher": "",
+                "symfony/process": ""
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "2.8-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Console\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Console Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-07-26T11:13:39+00:00"
+        },
+        {
+            "name": "symfony/debug",
+            "version": "v3.0.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/debug.git",
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/debug/zipball/697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "reference": "697c527acd9ea1b2d3efac34d9806bf255278b0a",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.5.9",
+                "psr/log": "~1.0"
+            },
+            "conflict": {
+                "symfony/http-kernel": ">=2.3,<2.3.24|~2.4.0|>=2.5,<2.5.9|>=2.6,<2.6.2"
+            },
+            "require-dev": {
+                "symfony/class-loader": "~2.8|~3.0",
+                "symfony/http-kernel": "~2.8|~3.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "3.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Debug\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Debug Component",
+            "homepage": "https://symfony.com",
+            "time": "2016-07-30T07:22:48+00:00"
+        },
+        {
+            "name": "symfony/polyfill-mbstring",
+            "version": "v1.9.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/polyfill-mbstring.git",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "reference": "d0cd638f4634c16d8df4508e847f14e9e43168b8",
+                "shasum": ""
+            },
+            "require": {
+                "php": ">=5.3.3"
+            },
+            "suggest": {
+                "ext-mbstring": "For best performance"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.9-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Polyfill\\Mbstring\\": ""
+                },
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nicolas Grekas",
+                    "email": "p@tchwork.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony polyfill for the Mbstring extension",
+            "homepage": "https://symfony.com",
+            "keywords": [
+                "compatibility",
+                "mbstring",
+                "polyfill",
+                "portable",
+                "shim"
+            ],
+            "time": "2018-08-06T14:22:27+00:00"
+        }
+    ],
+    "packages-dev": [],
+    "aliases": [],
+    "minimum-stability": "stable",
+    "stability-flags": [],
+    "prefer-stable": false,
+    "prefer-lowest": false,
+    "platform": [],
+    "platform-dev": []
+}

--- a/tests/Violation/Filter/ViolationFilterChainTest.php
+++ b/tests/Violation/Filter/ViolationFilterChainTest.php
@@ -42,7 +42,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]
+     * @return array
      */
     public function emptyProvider(): array
     {
@@ -79,7 +79,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]|ViolationFilterInterface[][]
+     * @return array
      */
     public function matchingProvider(): array
     {
@@ -116,7 +116,7 @@ class ViolationFilterChainTest extends TestCase
     }
 
     /**
-     * @return ViolationInterface[][]|bool[][]|ViolationFilterInterface[][]
+     * @return array
      */
     public function nonMatchingProvider(): array
     {


### PR DESCRIPTION
This pull request fixes #21 

Using native Reflection, the target symbols are loaded in using the autoloader, thus contaminating the current code base. When the target for static analysis conflicts with the code base of DependencyGuard, this results in fatal errors.

The commits in this pull request use BetterReflection instead, which can apply static analysis of symbols, without having to load in the code.

The DependencyGuard command no longer registers the autoloader for vendor directories, as that will cause targets for analysis to be loaded in the active code base.
