### PR TITLE
1.0.6 - Support older version of BetterReflection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
         "composer/composer": "^1.6",
         "composer-plugin-api": "^1.1",
         "nikic/php-parser": "^3.0 | ^4.0",
-        "roave/better-reflection": "^3.1"
+        "roave/better-reflection": "^2.0 | ^3.1"
     },
     "require-dev": {
         "symfony/process": "@stable",


### PR DESCRIPTION
Version 3 of BetterReflection requires PHP parser 4, which in turn is
also required by PHPStan. PHPStan has a dependency on Symfony Console,
which supports 3 | 4 in more recent versions, and goes back to 2 in
older versions, which in turn force PHP parser 3 and thus becomes
incompatible with the newer version of BetterReflection.

With the new changes, Magento 2 projects and modules can be statically
analyzed by DependencyGuard.
