### PR TITLE
update composer.json for composer v2

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -22,7 +22,7 @@
         "php": "^7.1",
         "ext-SPL": "^7.1",
         "ext-json": "*",
-        "composer-plugin-api": "^1.1",
+        "composer-plugin-api": "^1.1 | ^2.0",
         "composer/composer": "^1.6",
         "nikic/php-parser": "^3.0 | ^4.0",
         "roave/better-reflection": "^2.0 | ^3.1",

--- a/src/Composer/Plugin.php
+++ b/src/Composer/Plugin.php
@@ -38,4 +38,32 @@ class Plugin implements PluginInterface, Capable
     {
         // There is nothing explicit that needs to happen.
     }
+    
+    /**
+     * Remove any hooks from Composer
+     *
+     * This will be called when a plugin is deactivated before being
+     * uninstalled, but also before it gets upgraded to a new version
+     * so the old one can be deactivated and the new one activated.
+     *
+     * @param Composer    $composer
+     * @param IOInterface $io
+     */
+    public function deactivate(Composer $composer, IOInterface $io): void
+    {
+        // There is nothing explicit that needs to happen.
+    }
+
+    /**
+     * Prepare the plugin to be uninstalled
+     *
+     * This will be called after deactivate.
+     *
+     * @param Composer    $composer
+     * @param IOInterface $io
+     */
+    public function uninstall(Composer $composer, IOInterface $io): void
+    {
+        // There is nothing explicit that needs to happen.
+    }
 }


### PR DESCRIPTION
fix error:
mediact/dependency-guard 1.1.1 requires composer-plugin-api ^1.1 -> found composer-plugin-api[2.0.0] but it does not match the constrain